### PR TITLE
Support for k8s.io/ingress-nginx-codefresh controller 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=v0.0.366
+VERSION=v0.0.374
 
 OUT_DIR=dist
 YEAR?=$(shell date +"%Y")

--- a/docs/releases/release_notes.md
+++ b/docs/releases/release_notes.md
@@ -23,7 +23,7 @@ cf version
 
 ```bash
 # download and extract the binary
-curl -L --output - https://github.com/codefresh-io/cli-v2/releases/download/v0.0.366/cf-linux-amd64.tar.gz | tar zx
+curl -L --output - https://github.com/codefresh-io/cli-v2/releases/download/v0.0.374/cf-linux-amd64.tar.gz | tar zx
 
 # move the binary to your $PATH
 mv ./cf-linux-amd64 /usr/local/bin/cf
@@ -36,7 +36,7 @@ cf version
 
 ```bash
 # download and extract the binary
-curl -L --output - https://github.com/codefresh-io/cli-v2/releases/download/v0.0.366/cf-darwin-amd64.tar.gz | tar zx
+curl -L --output - https://github.com/codefresh-io/cli-v2/releases/download/v0.0.374/cf-darwin-amd64.tar.gz | tar zx
 
 # move the binary to your $PATH
 mv ./cf-darwin-amd64 /usr/local/bin/cf

--- a/manifests/runtime.yaml
+++ b/manifests/runtime.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: "{{ namespace }}"
 spec:
   defVersion: 1.0.1
-  version: 0.0.366
+  version: 0.0.374
   bootstrapSpecifier: github.com/codefresh-io/cli-v2/manifests/argo-cd
   components:
     - name: events

--- a/pkg/util/ingress/util.go
+++ b/pkg/util/ingress/util.go
@@ -65,9 +65,10 @@ const (
 	IngressControllerTraefik         ingressControllerType = "traefik.io/ingress-controller"
 	IngressControllerAmbassador      ingressControllerType = "getambassador.io/ingress-controller"
 	IngressControllerALB             ingressControllerType = "ingress.k8s.aws/alb"
+	IngressControllerNginxCodefresh  ingressControllerType = "k8s.io/ingress-nginx-codefresh"
 )
 
-var SupportedControllers = []ingressControllerType{IngressControllerNginxCommunity, IngressControllerNginxEnterprise, IngressControllerIstio, IngressControllerTraefik, IngressControllerAmbassador, IngressControllerALB}
+var SupportedControllers = []ingressControllerType{IngressControllerNginxCommunity, IngressControllerNginxEnterprise, IngressControllerIstio, IngressControllerTraefik, IngressControllerAmbassador, IngressControllerALB, IngressControllerNginxCodefresh}
 
 func (c baseController) Name() string {
 	return c.name


### PR DESCRIPTION
### What:
PR adds `k8s.io/ingress-nginx-codefresh` as supported ingress controller type

### Why:
Codefresh onprem installation (with Argo-Platform) by default deploys ingress-nginx controller (ref: https://github.com/kubernetes/ingress-nginx/tree/main/charts/ingress-nginx) with the following configuration:
```yaml
ingress-nginx:
  enabled: true
  controller:
    ingressClassResource:
      enabled: true
      default: false
      controllerValue: "k8s.io/ingress-nginx-codefresh"
      name: nginx-codefresh
```

The goal is to make it possible to install Codefresh onprem (with Argo-Platfrom) and V2 runtime on the same cluster using the same ingress controller.

### Notes:
CR-12013