### PR TITLE
Create /home/codefresh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,6 @@ RUN adduser \
     --gecos "" \
     --home "/home/codefresh" \
     --shell "/sbin/nologin" \
-    --no-create-home \
     --uid 10001 \
     codefresh
 


### PR DESCRIPTION
When using the image, you need to create a context By default the context is created in /home/codefresh but this folder does not exist It would be a lot easier if the folder exists instead of having to create and manage the context inna different locations