### PR TITLE
fix: add-cluster functionality for k8s 1.27

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=v0.1.50
+VERSION=v0.1.51
 
 OUT_DIR=dist
 YEAR?=$(shell date +"%Y")

--- a/docs/releases/release_notes.md
+++ b/docs/releases/release_notes.md
@@ -23,7 +23,7 @@ cf version
 
 ```bash
 # download and extract the binary
-curl -L --output - https://github.com/codefresh-io/cli-v2/releases/download/v0.1.42/cf-linux-amd64.tar.gz | tar zx
+curl -L --output - https://github.com/codefresh-io/cli-v2/releases/download/v0.1.51/cf-linux-amd64.tar.gz | tar zx
 
 # move the binary to your $PATH
 mv ./cf-linux-amd64 /usr/local/bin/cf
@@ -36,7 +36,7 @@ cf version
 
 ```bash
 # download and extract the binary
-curl -L --output - https://github.com/codefresh-io/cli-v2/releases/download/v0.1.42/cf-darwin-amd64.tar.gz | tar zx
+curl -L --output - https://github.com/codefresh-io/cli-v2/releases/download/v0.1.51/cf-darwin-amd64.tar.gz | tar zx
 
 # move the binary to your $PATH
 mv ./cf-darwin-amd64 /usr/local/bin/cf

--- a/pkg/util/kube/kube.go
+++ b/pkg/util/kube/kube.go
@@ -566,7 +566,7 @@ func deleteJob(ctx context.Context, client kubernetes.Interface, job *batchv1.Jo
 
 func getPodByJob(ctx context.Context, client kubernetes.Interface, job *batchv1.Job) (*v1.Pod, error) {
 	pods, err := client.CoreV1().Pods(job.GetNamespace()).List(ctx, metav1.ListOptions{
-		LabelSelector: "controller-uid=" + job.Spec.Selector.MatchLabels["controller-uid"],
+		LabelSelector: "controller-uid=" + job.Labels["controller-uid"],
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## What
In this PR, we are making a simple change to ensure that our CLI supports adding Kubernetes clusters with version 1.27. The change involves modifying the way we find the pod owned by a job using the label.

## Why
These changes are being made to accommodate the changes introduced in Kubernetes version 1.27. In version 1.27, pods owned by a Job now use the labels `batch.kubernetes.io/job-name` and `batch.kubernetes.io/controller-uid`. This is a change from the previous labels `job-name` and `controller-uid`, which were used for compatibility. By making this adjustment, we ensure that our CLI is compatible with Kubernetes 1.27 and can correctly identify pods owned by a job.

## Notes
Link to the changelog - https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.27.md#api-change-3