### PR TITLE
fix(dockerfile): take `GITHUB_TOKEN` from secrets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,9 @@ RUN adduser \
     --uid 10001 \
     codefresh
 
-ARG GITHUB_TOKEN
-RUN git config \
+RUN --mount=type=secret,id=GITHUB_TOKEN \
+    GITHUB_TOKEN=$(cat /run/secrets/GITHUB_TOKEN) \
+    git config \
     --global \
     url."https://github:${GITHUB_TOKEN}@github.com".insteadOf \
     "https://github.com"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=v0.1.62
+VERSION=v0.1.63
 
 OUT_DIR=dist
 YEAR?=$(shell date +"%Y")

--- a/build/ci.yaml
+++ b/build/ci.yaml
@@ -36,6 +36,15 @@ steps:
           on:
             - success
 
+  prepare_build_secrets:
+    stage: Prepare
+    title: 'Prepare build secrets'
+    image: alpine
+    commands:
+      - export GITHUB_TOKEN_PATH=${{CF_VOLUME_PATH}}/GITHUB_TOKEN
+      - cf_export GITHUB_TOKEN_PATH
+      - echo $GITHUB_TOKEN > $GITHUB_TOKEN_PATH
+
   compare_versions:
     stage: Prepare
     title: compare versions
@@ -121,14 +130,18 @@ steps:
     buildkit: true
     disable_push: true
     build_arguments:
-      - GITHUB_TOKEN=${{GITHUB_TOKEN}}
       - SEGMENT_WRITE_KEY=${{SEGMENT_WRITE_KEY}}
+    secrets:
+      - id=GITHUB_TOKEN,src=${{GITHUB_TOKEN_PATH}}
     when:
       condition:
         all:
           isBinary: '"${{REPO_TYPE}}" != "lib"'
       steps:
         - name: compare_versions
+          on:
+            - success
+        - name: prepare_build_secrets
           on:
             - success
 

--- a/docs/releases/release_notes.md
+++ b/docs/releases/release_notes.md
@@ -23,7 +23,7 @@ cf version
 
 ```bash
 # download and extract the binary
-curl -L --output - https://github.com/codefresh-io/cli-v2/releases/download/v0.1.62/cf-linux-amd64.tar.gz | tar zx
+curl -L --output - https://github.com/codefresh-io/cli-v2/releases/download/v0.1.63/cf-linux-amd64.tar.gz | tar zx
 
 # move the binary to your $PATH
 mv ./cf-linux-amd64 /usr/local/bin/cf
@@ -36,7 +36,7 @@ cf version
 
 ```bash
 # download and extract the binary
-curl -L --output - https://github.com/codefresh-io/cli-v2/releases/download/v0.1.62/cf-darwin-amd64.tar.gz | tar zx
+curl -L --output - https://github.com/codefresh-io/cli-v2/releases/download/v0.1.63/cf-darwin-amd64.tar.gz | tar zx
 
 # move the binary to your $PATH
 mv ./cf-darwin-amd64 /usr/local/bin/cf


### PR DESCRIPTION
## What

This takes `GITHUB_TOKEN` from secrets instead of build args.

## Why

Security reasons.

## Notes

—