### PR TITLE
feat: update cli to retrieve promotion commits for product release steps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=v0.1.65
+VERSION=v0.1.66
 
 OUT_DIR=dist
 YEAR?=$(shell date +"%Y")

--- a/cmd/commands/product-release.go
+++ b/cmd/commands/product-release.go
@@ -51,7 +51,7 @@ query getProductReleasesList(
 			steps {
 				environmentName
 				status
-				promotionCommits {
+				applications {
 					applicationId {
 						runtime
 						namespace

--- a/cmd/commands/product-release.go
+++ b/cmd/commands/product-release.go
@@ -67,7 +67,7 @@ query getProductReleasesList(
 }
 `
 
-const v0_13_4_query = `
+const pre_v1_3120_1_query = `
 query getProductReleasesList(
 	$productName: String!
 	$filters: ProductReleaseFiltersArgs!
@@ -160,9 +160,9 @@ func runProductReleaseList(ctx context.Context, filterArgs platmodel.ProductRele
 
 	productReleasesPage, err := client.GraphqlAPI[productReleaseSlice](ctx, cfConfig.NewClient().InternalClient(), latest_query, variables)
 	if err != nil {
-		if strings.Contains(err.Error(), "Cannot query field \\\"promotionCommits\\\" on type \\\"ProductReleaseStep\\\".") {
-			log.G().Warn("codefresh version v0.13.4 or older detected. Using v0.13.4 query which excludes promotionCommits.")
-			productReleasesPage, err = client.GraphqlAPI[productReleaseSlice](ctx, cfConfig.NewClient().InternalClient(), v0_13_4_query, variables)
+		if strings.Contains(err.Error(), "Cannot query field \\\"applications\\\" on type \\\"ProductReleaseStep\\\".") {
+			log.G().Warn("codefresh version older than v1.3120.1 detected. Using pre v1.3120.1 query which excludes applications.")
+			productReleasesPage, err = client.GraphqlAPI[productReleaseSlice](ctx, cfConfig.NewClient().InternalClient(), pre_v1_3120_1_query, variables)
 		}
 		if err != nil {
 			return fmt.Errorf("failed to get product releases: %s", err.Error())

--- a/cmd/commands/product-release.go
+++ b/cmd/commands/product-release.go
@@ -111,6 +111,14 @@ query getProductReleasesList(
 			steps {
 				environmentName
 				status
+				promotionCommits {
+					applicationId {
+						runtime
+						namespace
+						name
+					}
+					commitSha
+				}
 			}
 			status
 			}

--- a/cmd/commands/product-release.go
+++ b/cmd/commands/product-release.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/codefresh-io/cli-v2/pkg/util"
 
+	"github.com/codefresh-io/cli-v2/pkg/log"
 	"github.com/codefresh-io/go-sdk/pkg/client"
 	platmodel "github.com/codefresh-io/go-sdk/pkg/model/promotion-orchestrator"
 	"github.com/spf13/cobra"
@@ -36,6 +37,55 @@ type (
 		Node map[string]any `json:"node"`
 	}
 )
+
+const latest_query = `
+query getProductReleasesList(
+	$productName: String!
+	$filters: ProductReleaseFiltersArgs!
+	$pagination: SlicePaginationArgs
+) {
+	productReleases(productName: $productName, filters: $filters, pagination: $pagination) {
+		edges {
+			node {
+			releaseId
+			steps {
+				environmentName
+				status
+				promotionCommits {
+					applicationId {
+						runtime
+						namespace
+						name
+					}
+					commitSha
+				}
+			}
+			status
+			}
+		}
+	}
+}
+`
+
+const v0_13_4_query = `
+query getProductReleasesList(
+	$productName: String!
+	$filters: ProductReleaseFiltersArgs!
+	$pagination: SlicePaginationArgs
+) {
+	productReleases(productName: $productName, filters: $filters, pagination: $pagination) {
+		edges {
+			node {
+			releaseId
+			steps {
+				environmentName
+				status
+			}
+			status
+			}
+		}
+	}
+}`
 
 func NewProductReleaseCommand() *cobra.Command {
 	cmd := &cobra.Command{
@@ -98,33 +148,7 @@ func newProductReleaseListCommand() *cobra.Command {
 
 // client here is for mock testings usage
 func runProductReleaseList(ctx context.Context, filterArgs platmodel.ProductReleaseFiltersArgs, productName string, pageLimit int) error {
-	query := `
-query getProductReleasesList(
-	$productName: String!
-	$filters: ProductReleaseFiltersArgs!
-	$pagination: SlicePaginationArgs
-) {
-	productReleases(productName: $productName, filters: $filters, pagination: $pagination) {
-		edges {
-			node {
-			releaseId
-			steps {
-				environmentName
-				status
-				promotionCommits {
-					applicationId {
-						runtime
-						namespace
-						name
-					}
-					commitSha
-				}
-			}
-			status
-			}
-		}
-	}
-}`
+
 	// add pagination - default for now is last 20
 	variables := map[string]any{
 		"filters":     filterArgs,
@@ -134,9 +158,15 @@ query getProductReleasesList(
 		},
 	}
 
-	productReleasesPage, err := client.GraphqlAPI[productReleaseSlice](ctx, cfConfig.NewClient().InternalClient(), query, variables)
+	productReleasesPage, err := client.GraphqlAPI[productReleaseSlice](ctx, cfConfig.NewClient().InternalClient(), latest_query, variables)
 	if err != nil {
-		return fmt.Errorf("failed to get product releases: %w", err)
+		if strings.Contains(err.Error(), "Cannot query field \\\"promotionCommits\\\" on type \\\"ProductReleaseStep\\\".") {
+			log.G().Warn("codefresh version v0.13.4 or older detected. Using v0.13.4 query which excludes promotionCommits.")
+			productReleasesPage, err = client.GraphqlAPI[productReleaseSlice](ctx, cfConfig.NewClient().InternalClient(), v0_13_4_query, variables)
+		}
+		if err != nil {
+			return fmt.Errorf("failed to get product releases: %s", err.Error())
+		}
 	}
 
 	if len(productReleasesPage.Edges) == 0 {


### PR DESCRIPTION
## What
Adding promotion commits to product release steps if the version of codefresh is compatible. I've added a fall back in case the cli is connected to an old version of codefresh (on prem).

## Why
A customer wanted to know the commit created by promotions for each step of a product release for each application. See Jira ticket for details.

## Notes
Jira: https://codefresh-io.atlassian.net/browse/CR-25720