### PR TITLE
fix: correct function signature and remove unused app proxy code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=v0.2.1
+VERSION=v0.2.2
 
 OUT_DIR=dist
 YEAR?=$(shell date +"%Y")

--- a/cmd/commands/integrations.go
+++ b/cmd/commands/integrations.go
@@ -67,7 +67,7 @@ func newIntegrationCommand() *cobra.Command {
 		Use:               "integration",
 		Aliases:           []string{"integrations", "intg"},
 		Short:             "Manage integrations with git providers, container registries and more",
-		PersistentPreRunE: getAppProxyClient(runtime, &apClient),
+		PersistentPreRunE: getppProxyClient(&runtime, &apClient),
 		Args:              cobra.NoArgs, // Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
 		Run: func(cmd *cobra.Command, args []string) {
 			cmd.HelpFunc()(cmd, args)
@@ -405,7 +405,7 @@ func runGitIntegrationDeregisterCommand(ctx context.Context, apClient ap.AppProx
 	return nil
 }
 
-func getAppProxyClient(runtime string, apClient *ap.AppProxyAPI) func(*cobra.Command, []string) error {
+func getAppProxyClient(runtime *string, apClient *ap.AppProxyAPI) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
 		ctx := cmd.Context()
 
@@ -413,7 +413,7 @@ func getAppProxyClient(runtime string, apClient *ap.AppProxyAPI) func(*cobra.Com
 			return err
 		}
 
-		runtimeName, err := ensureRuntimeName(ctx, []string{runtime}, nil)
+		runtimeName, err := ensureRuntimeName(ctx, []string{*runtime}, nil)
 		if err != nil {
 			return fmt.Errorf("failed to get runtime name: %w", err)
 		}

--- a/cmd/commands/integrations.go
+++ b/cmd/commands/integrations.go
@@ -67,7 +67,7 @@ func newIntegrationCommand() *cobra.Command {
 		Use:               "integration",
 		Aliases:           []string{"integrations", "intg"},
 		Short:             "Manage integrations with git providers, container registries and more",
-		PersistentPreRunE: getppProxyClient(&runtime, &apClient),
+		PersistentPreRunE: getAppProxyClient(&runtime, &apClient),
 		Args:              cobra.NoArgs, // Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
 		Run: func(cmd *cobra.Command, args []string) {
 			cmd.HelpFunc()(cmd, args)

--- a/cmd/commands/version.go
+++ b/cmd/commands/version.go
@@ -17,10 +17,8 @@ package commands
 import (
 	"fmt"
 
-	"github.com/codefresh-io/cli-v2/internal/log"
 	"github.com/codefresh-io/cli-v2/internal/store"
 
-	ap "github.com/codefresh-io/go-sdk/pkg/appproxy"
 	"github.com/spf13/cobra"
 )
 
@@ -44,32 +42,6 @@ func newVersionCommand() *cobra.Command {
 				fmt.Printf("    GoVersion: %s\n", s.Version.GoVersion)
 				fmt.Printf("    GoCompiler: %s\n", s.Version.GoCompiler)
 				fmt.Printf("    Platform: %s\n", s.Version.Platform)
-
-				// try to get app proxy version info
-				if err := cfConfig.Load(cmd, args); err != nil {
-					return err
-				}
-
-				runtime := ""
-				var apClient ap.AppProxyAPI
-
-				if err := getAppProxyClient(runtime, &apClient)(cmd, args); err != nil {
-					// can't create client, print error only if in debug level
-					log.G(cmd.Context()).Debug(fmt.Errorf("failed to build app proxy client: %w", err))
-					return nil
-				}
-
-				apInfo, err := apClient.VersionInfo().VersionInfo(cmd.Context())
-				if err != nil {
-					// can't get version, print error only if in debug level
-					log.G(cmd.Context()).Debug(fmt.Errorf("failed to get app proxy version info: %w", err))
-					return nil
-				}
-
-				fmt.Printf("\nAppProxy:\n")
-				fmt.Printf("    Version: %s\n", apInfo.Version)
-				fmt.Printf("    PlatformHost: %s\n", apInfo.PlatformHost)
-				fmt.Printf("    PlatformVersion: %s\n", apInfo.PlatformVersion)
 			} else {
 				fmt.Printf("%+s\n", s.Version.Version)
 			}


### PR DESCRIPTION
## What
* Updated the getAppProxyClient function to accept a pointer for the runtime parameter.
* Removed unused app proxy version retrieval logic from the newVersionCommand function to clean up the code and improve maintainability.

## Why
using the pointer ensures the appproxy Client connects to the runtime supplied in the `--runtime` flag

## Notes
the original issue originated from #757