### PR TITLE
fix: update flag names for git source repository command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=v0.2.3
+VERSION=v0.2.4
 
 OUT_DIR=dist
 YEAR?=$(shell date +"%Y")

--- a/cmd/commands/git-source.go
+++ b/cmd/commands/git-source.go
@@ -368,7 +368,7 @@ func newGitSourceEditCommand() *cobra.Command {
 
 			gsName = args[1]
 			if repo == "" {
-				return fmt.Errorf("must enter a valid value to --git-source-repo. Example: https://github.com/owner/repo-name.git/path/to/dir")
+				return fmt.Errorf("must enter a valid value to --git-src-repo. Example: https://github.com/owner/repo-name.git/path/to/dir")
 			}
 
 			return nil
@@ -396,7 +396,7 @@ func newGitSourceEditCommand() *cobra.Command {
 
 	cmd.Flags().StringVar(&include, "include", "", "files to include. can be either filenames or a glob")
 	cmd.Flags().StringVar(&exclude, "exclude", "", "files to exclude. can be either filenames or a glob")
-	cmd.Flags().StringVar(&repo, "git-source-repo", "", "Repository URL [%sGIT_SOURCE_GIT_REPO]")
+	cmd.Flags().StringVar(&repo, "git-src-repo", "", "Repository URL [%sGIT_SOURCE_GIT_REPO]")
 
 	return cmd
 }

--- a/docs/commands/cli-v2_git-source_edit.md
+++ b/docs/commands/cli-v2_git-source_edit.md
@@ -17,10 +17,10 @@ cli-v2 git-source edit RUNTIME_NAME GITSOURCE_NAME [flags]
 ### Options
 
 ```
-      --exclude string           files to exclude. can be either filenames or a glob
-      --git-source-repo string   Repository URL [%sGIT_SOURCE_GIT_REPO]
-  -h, --help                     help for edit
-      --include string           files to include. can be either filenames or a glob
+      --exclude string        files to exclude. can be either filenames or a glob
+      --git-src-repo string   Repository URL [%sGIT_SOURCE_GIT_REPO]
+  -h, --help                  help for edit
+      --include string        files to include. can be either filenames or a glob
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
## What
fix the `git-source create` command flag to use `--git-src-repo` instead of `--git-source-repo`

## Why
the change was done by mistake

## Notes
<!-- Add any additional notes here -->