### PR TITLE
fix: update version to v0.2.5 and rename git-source-repo flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=v0.2.4
+VERSION=v0.2.5
 
 OUT_DIR=dist
 YEAR?=$(shell date +"%Y")

--- a/cmd/commands/git-source.go
+++ b/cmd/commands/git-source.go
@@ -148,9 +148,9 @@ func newGitSourceCreateCommand() *cobra.Command {
 	cmd.Flags().BoolVar(&createRepo, "create-repo", false, "If true, will create the specified git-source repo in case it doesn't already exist")
 	cmd.Flags().StringVar(&include, "include", "", "files to include. can be either filenames or a glob")
 	cmd.Flags().StringVar(&exclude, "exclude", "", "files to exclude. can be either filenames or a glob")
-	cmd.Flags().StringVar(&repo, "git-source-repo", "", "Repository URL [%sGIT_SOURCE_GIT_REPO]")
+	cmd.Flags().StringVar(&repo, "git-src-repo", "", "Repository URL [%sGIT_SOURCE_GIT_REPO]")
 
-	util.Die(viper.BindEnv("git-source-repo", "GIT_SOURCE_GIT_REPO"))
+	util.Die(viper.BindEnv("git-src-repo", "GIT_SOURCE_GIT_REPO"))
 
 	return cmd
 }

--- a/docs/commands/cli-v2_git-source_create.md
+++ b/docs/commands/cli-v2_git-source_create.md
@@ -17,11 +17,11 @@ cli-v2 git-source create RUNTIME_NAME GITSOURCE_NAME [flags]
 ### Options
 
 ```
-      --create-repo              If true, will create the specified git-source repo in case it doesn't already exist
-      --exclude string           files to exclude. can be either filenames or a glob
-      --git-source-repo string   Repository URL [%sGIT_SOURCE_GIT_REPO]
-  -h, --help                     help for create
-      --include string           files to include. can be either filenames or a glob
+      --create-repo           If true, will create the specified git-source repo in case it doesn't already exist
+      --exclude string        files to exclude. can be either filenames or a glob
+      --git-src-repo string   Repository URL [%sGIT_SOURCE_GIT_REPO]
+  -h, --help                  help for create
+      --include string        files to include. can be either filenames or a glob
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
- Bump version number in Makefile.
- Rename the git-source-repo flag to git-src-repo for consistency.
- Update documentation to reflect the new flag name.

## What
<!-- What is changing in this PR? -->

## Why
<!-- Why are these changes being made? -->

## Notes
<!-- Add any additional notes here -->