### PR TITLE
fix github api url

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=v0.2.10
+VERSION=v0.2.11
 
 OUT_DIR=dist
 YEAR?=$(shell date +"%Y")

--- a/docs/releases/release_notes.md
+++ b/docs/releases/release_notes.md
@@ -15,7 +15,7 @@ cf version
 
 ```bash
 # download and extract the binary
-curl -L --output - https://github.com/codefresh-io/cli-v2/releases/download/v0.2.8/cf-linux-amd64.tar.gz | tar zx
+curl -L --output - https://github.com/codefresh-io/cli-v2/releases/download/v0.2.11/cf-linux-amd64.tar.gz | tar zx
 
 # move the binary to your $PATH
 mv ./cf-linux-amd64 /usr/local/bin/cf
@@ -28,7 +28,7 @@ cf version
 
 ```bash
 # download and extract the binary
-curl -L --output - https://github.com/codefresh-io/cli-v2/releases/download/v0.2.8/cf-darwin-amd64.tar.gz | tar zx
+curl -L --output - https://github.com/codefresh-io/cli-v2/releases/download/v0.2.11/cf-darwin-amd64.tar.gz | tar zx
 
 # move the binary to your $PATH
 mv ./cf-darwin-amd64 /usr/local/bin/cf

--- a/internal/git/provider_github.go
+++ b/internal/git/provider_github.go
@@ -49,7 +49,7 @@ func NewGithubProvider(baseURL string, client *http.Client) (Provider, error) {
 		return nil, err
 	}
 
-	if u.Host == GITHUB_CLOUD_DOMAIN {
+	if strings.Contains(u.Hostname(), GITHUB_CLOUD_DOMAIN) {
 		u, _ = url.Parse(GITHUB_CLOUD_API_URL)
 	} else if u.Path == "" {
 		u.Path = GITHUB_REST_ENDPOINT
@@ -106,7 +106,8 @@ func (g *github) verifyToken(ctx context.Context, token string, requiredScopes [
 	reqHeaders := map[string]string{
 		"Authorization": "token " + token,
 	}
-	req, err := httputil.NewRequest(ctx, http.MethodHead, g.apiURL.String(), reqHeaders, nil)
+	url := g.apiURL.String()
+	req, err := httputil.NewRequest(ctx, http.MethodHead, url, reqHeaders, nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## What
previously, when an account `csdpSettings` would contain apiUrl of `https://api.github.com`, the token validation check would call `https://api.github.com/api/v3`.

i fixed the githubProvider code to check for "github.com" in the hostname, and if it exists - to not add any `/api/v3` path to the base url at all.

## Why
i guess `https://api.github.com/api/v3` use to work, but recently github changed their side, and now it returns 404.

## Notes
<!-- Add any additional notes here -->